### PR TITLE
Fix misspellings in sysconfig doc

### DIFF
--- a/Doc/library/sysconfig.rst
+++ b/Doc/library/sysconfig.rst
@@ -84,13 +84,13 @@ Python currently supports nine schemes:
   through Distutils and the *user* option is used.  This scheme defines paths
   located under the user home directory.
 - *posix_venv*: scheme for :mod:`Python virtual environments <venv>` on POSIX
-  platforms; by default it is the same as *posix_prefix* .
+  platforms; by default it is the same as *posix_prefix*.
 - *nt*: scheme for NT platforms like Windows.
 - *nt_user*: scheme for NT platforms, when the *user* option is used.
 - *nt_venv*: scheme for :mod:`Python virtual environments <venv>` on NT
-  platforms; by default it is the same as *nt* .
-- *venv*: a scheme with values from ether *posix_venv* or *nt_venv* depending
-  on the platform Python runs on
+  platforms; by default it is the same as *nt*.
+- *venv*: a scheme with values from either *posix_venv* or *nt_venv* depending
+  on the platform Python runs on.
 - *osx_framework_user*: scheme for macOS, when the *user* option is used.
 
 Each scheme is itself composed of a series of paths and each path has a unique
@@ -187,7 +187,7 @@ identifier.  Python currently uses eight paths:
    platform is used.
 
    If *vars* is provided, it must be a dictionary of variables that will update
-   the dictionary return by :func:`get_config_vars`.
+   the dictionary returned by :func:`get_config_vars`.
 
    If *expand* is set to ``False``, the path will not be expanded using the
    variables.


### PR DESCRIPTION
This should be backported to 3.12 and 3.11 as well.

<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--22.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->